### PR TITLE
Write a scope.thumbStyle method that updates the position of the seek

### DIFF
--- a/app/scripts/directives/seekBar.js
+++ b/app/scripts/directives/seekBar.js
@@ -34,6 +34,10 @@
           return {width: percentString()};
         };
 
+        scope.thumbStyle = function() {
+          return {left: percentString()};
+        };
+
         scope.onClickSeekBar = function(event) {
           updateValue(event);
         };

--- a/app/templates/directives/seek_bar.html
+++ b/app/templates/directives/seek_bar.html
@@ -1,4 +1,4 @@
 <div class="seek-bar" ng-click="onClickSeekBar($event)">
   <div class="fill" ng-style="fillStyle()"></div>
-  <div class="thumb" ng-mousedown="trackThumb()"></div>
+  <div class="thumb" ng-style="thumbStyle()" ng-mousedown="trackThumb()"></div>
 </div>


### PR DESCRIPTION
3)  Write a `scope.thumbStyle` method that updates the position of the seek bar thumb.
4)  Explain, in your own words, what happens when you remove `$apply` [from the `trackThumb` method]. _(see below)_

**Removing `$apply`:**

Removing `$apply` from the `trackThumb` method in `app/scripts/directives/seekBar.js` will cause the drag action on the thumb control to not update its position in the seek bar. This is because Angular will not detect that the percentage was updated and so will not update the display (that is, the display won't be bound to the updated percentage).  By wrapping the percentage change in `$apply()`, Angular's bindings will check for an updated value after `trackThumb` complete.

 