### PR TITLE
Assignment: checkpoint #10 (optional)

### DIFF
--- a/app/scripts/controllers/PlayerBarCtrl.js
+++ b/app/scripts/controllers/PlayerBarCtrl.js
@@ -1,10 +1,11 @@
 (function() {
-  function PlayerBarCtrl(Fixtures, SongPlayer) {
+  function PlayerBarCtrl($scope, Fixtures, SongPlayer) {
     this.albumData = Fixtures.getAlbum();
     this.songPlayer = SongPlayer;
+    this.songPlayer.registerScope($scope);
   }
 
   angular
     .module('blocJams')
-    .controller('PlayerBarCtrl', ['Fixtures', 'SongPlayer', PlayerBarCtrl]);
+    .controller('PlayerBarCtrl', ['$scope', 'Fixtures', 'SongPlayer', PlayerBarCtrl]);
 })();

--- a/app/scripts/services/SongPlayer.js
+++ b/app/scripts/services/SongPlayer.js
@@ -1,5 +1,5 @@
 (function() {
-  function SongPlayer($rootScope, Utility, Fixtures) {
+  function SongPlayer(Utility, Fixtures) {
     var SongPlayer = {};
 
     /**
@@ -13,6 +13,12 @@
     * @type {Object}
     */
     var currentBuzzObject = null;
+
+    /**
+    * @desc Scope from controller for updating views
+    * @type {Object}
+    */
+    var controllerScope = null;
 
     /**
     * @function setSong
@@ -29,11 +35,13 @@
         preload: true
       });
 
-      currentBuzzObject.bind('timeupdate', function() {
-        $rootScope.$apply(function() {
-          SongPlayer.currentTime = currentBuzzObject.getTime();
+      if (controllerScope) {
+        currentBuzzObject.bind('timeupdate', function() {
+          controllerScope.$apply(function() {    // TODO: is there a way to support more than one scope at a time?
+            SongPlayer.currentTime = currentBuzzObject.getTime();
+          });
         });
-      });
+      }
 
       SongPlayer.currentSong = song;
       SongPlayer.currentSong.artist = currentAlbum.artist;
@@ -167,10 +175,19 @@
       }
     };
 
+    /**
+    * @function registerScope
+    * @desc Register a view scope for display updates.  Only one scope is recognized at a time.
+    * @param {Object} scope
+    */
+    SongPlayer.registerScope = function(scope) {
+      controllerScope = scope;
+    };
+
     return SongPlayer;
   }
 
   angular
     .module('blocJams')
-    .factory('SongPlayer', ['$rootScope', 'Utility', 'Fixtures', SongPlayer]);
+    .factory('SongPlayer', ['Utility', 'Fixtures', SongPlayer]);
  })();

--- a/app/scripts/services/SongPlayer.js
+++ b/app/scripts/services/SongPlayer.js
@@ -34,6 +34,7 @@
         formats: ['mp3'],
         preload: true
       });
+      currentBuzzObject.setVolume(SongPlayer.volume);
 
       if (controllerScope) {
         currentBuzzObject.bind('timeupdate', function() {
@@ -169,10 +170,11 @@
     * @param {Number} volume
     */
     SongPlayer.setVolume = function(volume) {
+      var newVolume = Utility.valBetween(volume, 0, SongPlayer.maxVolume);
       if (currentBuzzObject) {
-        var newVolume = Utility.valBetween(volume, 0, SongPlayer.maxVolume);
         currentBuzzObject.setVolume(newVolume);
       }
+      SongPlayer.volume = newVolume;
     };
 
     /**


### PR DESCRIPTION
5)  **Optional**: It's possible to refactor the `$rootScope.$apply` method to not use `$rootScope` at all. The premise lies with the concept of "registering" only the controllers that need to watch the current time of a song update. We suggest creating an additional feature branch if you choose to attempt this refactoring.

###### Notes re my solution:

My implemented solution will only work for a single controller/view at a time.  I can imagine using my new `songPlayer.registerScope()` to inform the service that more than one controller is subscribed (storing the provided scopes as a Set), but not sure how to handle the `$apply` logic to do so.  

It would seem that I could just loop through all scopes in the registered set to call $apply and I suppose I could use a closure to assure each are informed of the same value -- *am I on the right track*?

----
_Also_, discovered that volume wasn't being maintained between song selections, so force current `SongPlayer.volume` to be applied during `setSong()` and track changes to it (as should have been done in original solution).